### PR TITLE
Adding the main package object type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
 [compat]
 julia = "1"

--- a/src/PartialCopulaCondIndTests.jl
+++ b/src/PartialCopulaCondIndTests.jl
@@ -1,5 +1,6 @@
 module PartialCopulaCondIndTests
 
+include("conditional_independence_test.jl")
 include("generalized_correlation.jl")
 
 end

--- a/src/conditional_independence_test.jl
+++ b/src/conditional_independence_test.jl
@@ -1,0 +1,11 @@
+using StatsAPI: HypothesisTest
+
+abstract type ConditionalIndependenceTest <: HypothesisTest end
+abstract type IndependenceTest <: HypothesisTest end
+abstract type PartialCopulaEstimator end
+
+
+struct PartialCopulaCondIndTest <: ConditionalIndependenceTest
+    partial_copula_estimator::PartialCopulaEstimator
+    independence_test::IndependenceTest
+end


### PR DESCRIPTION
### Description

We add the basic package object type `PartialCopulaCondIndTest`. This takes two integral components:

- A `PartialCopulaEstimator` 
- An `IndependenceTest`

Which are themselves abstract types that must be implemented and provided.